### PR TITLE
add whitespace skip for CRLF compatibility

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -146,7 +146,10 @@ pub enum Token {
     Text,
 
     #[regex(r"([_A-Za-z][_A-Za-z\d]*|[_A-Za-z]+(-[A-Za-z\d_]+)+)!")]
-    MacroCall
+    MacroCall,
+
+    #[regex(r"[ \t\n\r\f]+", logos::skip)]
+    Whitespace,
 }
 
 pub fn lex_rsml<'a>(content: &'a str) -> logos::Lexer<'a, Token> {

--- a/src/utils/utils_lexer.rs
+++ b/src/utils/utils_lexer.rs
@@ -24,7 +24,10 @@ pub enum UtilsToken {
     UtilDeclaration,
 
     #[regex(r"[_a-zA-Z][-_A-Za-z\d]*", priority = 0)]
-    Text
+    Text,
+
+    #[regex(r"[ \t\n\r\f]+", logos::skip)]
+    Whitespace,
 }
 
 pub fn lex_rsml_utils<'a>(content: &'a str) -> logos::Lexer<'a, UtilsToken> {


### PR DESCRIPTION
Previously, the lexer would produce an "Unexpected Token" error on files with CRLF line endings. (The \r character was not ignored).

Note: This change ignores all whitespace characters using a Whitespace token with #[logos::skip]