### PR TITLE
Parse font assetId as int64 instead of float32.

### DIFF
--- a/src/parser/tuple/tuple_annotations/font.rs
+++ b/src/parser/tuple/tuple_annotations/font.rs
@@ -9,7 +9,7 @@ pub fn font_annotation(datatypes: &Vec<Datatype>) -> Datatype {
                 true => font_str,
                 false => &format!("rbxasset://fonts/families/{}.json", font_str)
             },
-            Datatype::Variant(Variant::Float32(num)) => &format!("rbxassetid://{}", num),
+            Datatype::Variant(Variant::Int64(num)) => &format!("rbxassetid://{}", num),
             _ => "rbxasset://fonts/families/SourceSansPro.json"
         }
     } else { "rbxasset://fonts/families/SourceSansPro.json" };


### PR DESCRIPTION
Straightforward change. Precision loss kicks in after 2^23 which produces incorrect results.